### PR TITLE
Feature/capturar processar armazenar partidas

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,7 @@
+# External API`s
+API_FOOTBALL_KEY = "apikey"
+
+# Database
+MONGODB_URI = "mongodb+srv://login:senha@cluster0.asdp1sn.mongodb.net/?retryWrites=true&w=majority"
+DB_NAME = "panda_scouts_db"
+COLLECTION_NAME = "standings" 

--- a/app/db.py
+++ b/app/db.py
@@ -9,12 +9,33 @@ class MongoDB:
     def __init__(self):
         self.client = MongoClient(getenv('MONGODB_URI'))
         self.db = self.client[getenv('DB_NAME')]
-        self.collection = self.db[getenv('COLLECTION_NAME')]
 
     def update_league_data(self, league_id: int, season: int, data: dict):
+        self.collection = self.db["standings"]
         query = {"league_info.id": league_id, "league_info.season": season}
         new_data = {"$set": data}
         self.collection.update_one(query, new_data, upsert=True)
+
+    def get_standings_data(self, league_id: int, season: int) -> dict:
+        """
+        Busca os dados de classificação de uma liga específica com base no ID da liga e na temporada.
+
+        Args:
+        - league_id (int): ID da liga.
+        - season (int): Temporada.
+
+        Returns:
+        - dict: Dados de classificação da liga.
+        """
+        query = {"league_info.id": league_id, "league_info.season": season}
+        self.collection = self.db["standings"]
+        result = self.collection.find_one(query)
+
+        if result:
+            return result
+        else:
+            raise ValueError(
+                f"No standings data found for league_id {league_id} and season {season}.")
 
     # Adicione aqui outras funções relacionadas a operações no banco de dados, se necessário.
     # Por exemplo, funções para consultar dados, deletar documentos, etc.

--- a/app/main.py
+++ b/app/main.py
@@ -74,14 +74,20 @@ async def update_standings_data(league_id: int, season: int):
 
 @app.get("/today-quartile-matches/{league_id}/{season}")
 async def get_today_quartile_matches(league_id: int, season: int):
+    """
+    Obtém os jogos do dia de uma liga que correspondem aos critérios do quartil
+    com base nas classificações das equipes.
+
+    Args:
+        league_id (int): O ID da liga.
+        season (int): O ano da temporada.
+
+    Returns:
+        dict: Um dicionário contendo a lista de jogos que atendem aos critérios.
+    """
     try:
-        # Obter dados de classificação da liga usando a função do services.py
         standings_data = services.fetch_standings_data(league_id, season)
-
-        # Obter os jogos do dia da coleção MongoDB usando a função do services.py
         today_matches = services.get_today_matches_from_db(league_id)
-
-        # Filtrar jogos de quartil com base nas classificações das equipes
         quartile_matches = services.filter_quartile_matches(
             today_matches, standings_data)
 
@@ -92,8 +98,13 @@ async def get_today_quartile_matches(league_id: int, season: int):
 
 @app.post("/update-today-matches-for-all-leagues")
 async def update_today_matches_for_all_leagues_endpoint():
+    """
+    Inicia a atualização dos jogos do dia para todas as ligas.
+
+    Returns:
+        dict: Um dicionário com uma mensagem indicando o resultado da atualização.
+    """
     try:
-        # Chame a função para atualizar os jogos do dia para todas as ligas
         services.update_today_matches_for_all_leagues()
 
         return {"message": "Atualização dos jogos do dia para todas as ligas concluída com sucesso"}

--- a/app/services.py
+++ b/app/services.py
@@ -1,6 +1,7 @@
 import json
 import http.client
 import db
+import datetime
 from os import getenv
 from dotenv import load_dotenv
 
@@ -61,3 +62,122 @@ async def update_league_data(league_id: int, season: int):
     data_json = json.loads(raw_data)
     organized_data = organize_data(data_json)
     db_instance.update_league_data(league_id, season, organized_data)
+
+
+def fetch_standings_data(league_id: int, season: int) -> dict:
+    """
+    Busca, em nosso banco, os dados de classificação de uma liga específica com base no ID da liga e na temporada.
+
+    Args:
+    - league_id (int): ID da liga.
+    - season (int): Temporada.
+
+    Returns:
+    - dict: Dados de classificação da liga.
+    """
+    return db_instance.get_standings_data(league_id, season)
+
+
+def filter_quartile_matches(today_matches: list, standings_data: dict) -> list:
+    """
+    Filtra os jogos do dia com base nas classificações das equipes.
+
+    Args:
+    - today_matches (list): Lista de informações completas dos jogos do dia.
+    - standings_data (dict): Dados de classificação da liga.
+
+    Returns:
+    - list: Uma lista de informações completas dos jogos que atendem aos critérios.
+    """
+    quartile_threshold = len(standings_data["standings"]) // 4
+
+    quartile_matches = []
+
+    for match in today_matches:
+        home_team_id = match["teams"]["home"]["id"]
+        away_team_id = match["teams"]["away"]["id"]
+
+        # Encontre as classificações das equipes
+        home_team_rank = next(
+            (team["rank"] for team in standings_data["standings"] if team["team_id"] == home_team_id), None)
+        away_team_rank = next(
+            (team["rank"] for team in standings_data["standings"] if team["team_id"] == away_team_id), None)
+
+        # Verifique se ambas as equipes estão no primeiro ou no último quartil
+        if home_team_rank is not None and away_team_rank is not None:
+            if home_team_rank <= quartile_threshold and away_team_rank > 3 * quartile_threshold:
+                quartile_matches.append(match)
+            elif away_team_rank <= quartile_threshold and home_team_rank > 3 * quartile_threshold:
+                quartile_matches.append(match)
+
+    return quartile_matches
+
+
+def update_today_matches_in_db(league_id: int, season: int):
+    """
+    Atualiza os jogos do dia no banco de dados MongoDB para uma liga específica.
+
+    Args:
+    - league_id (int): ID da liga.
+    - season (int): Temporada.
+
+    Esta função faz uma chamada à API externa para obter os jogos do dia e atualiza
+    o campo "today_matches" na coleção do MongoDB para a liga especificada.
+    """
+    conn = http.client.HTTPSConnection("api-football-v1.p.rapidapi.com")
+
+    headers = {
+        'X-RapidAPI-Key': API_FOOTBALL_KEY,
+        'X-RapidAPI-Host': "api-football-v1.p.rapidapi.com"
+    }
+
+    today = datetime.date.today().isoformat()
+    timezone = "America/Sao_Paulo"
+    status = "NS"
+
+    # Faz a consulta para obter os jogos do dia para a liga e temporada especificadas
+    conn.request(
+        "GET", f"/v3/fixtures?date={today}&league={league_id}&season={season}&timezone={timezone}&status={status}", headers=headers)
+
+    res = conn.getresponse()
+    data = res.read()
+
+    fixtures_data = json.loads(data.decode("utf-8"))
+
+    # Obtém os IDs dos jogos do dia
+    today_matches = fixtures_data.get("response", [])
+
+    # Atualiza o campo "today_matches" na coleção MongoDB para a liga especificada
+    db_instance.update_today_matches(league_id, season, today_matches)
+
+
+def update_today_matches_for_all_leagues():
+    try:
+        # Ler o arquivo leagues.json para obter a lista de ligas
+        with open("leagues.json", "r") as file:
+            leagues = json.load(file)
+
+        # Para cada liga na lista, chame a função para atualizar os jogos do dia
+        for league in leagues:
+            league_id = league["league_id"]
+            season = league["season"]
+            update_today_matches_in_db(league_id, season)
+
+        print("Atualização dos jogos do dia para todas as ligas concluída com sucesso")
+    except Exception as e:
+        print(f"Erro ao atualizar jogos do dia para todas as ligas: {str(e)}")
+
+
+def get_today_matches_from_db(league_id: int, season: int):
+    """
+    Obtém os jogos do dia para uma liga específica do banco de dados MongoDB.
+
+    Args:
+    - league_id (int): ID da liga.
+    - season (int): Temporada.
+
+    Returns:
+    - list: Uma lista de informações completas dos jogos do dia.
+    """
+    # Chama o método do banco de dados para obter os jogos do dia
+    return db_instance.get_today_matches(league_id, season)

--- a/docs/prompt-3.md
+++ b/docs/prompt-3.md
@@ -1,0 +1,251 @@
+## Prompt-1
+
+```
+Estou criando uma aplicação em FastAPI e voce me ajudará
+
+O objetivo é construir uma api que forneça estatisticas de jogos para sportsbetting.
+A principio, estamos armazenando e atualizando as tabelas de diversas ligas.
+O objetivo é, depois, extrair informações dos confrontos do dia/semana vigente para gerar análises e destacar estatísticas a partir de filtros.
+
+esse é o main.py:
+
+from fastapi import FastAPI, HTTPException
+from apscheduler.schedulers.background import BackgroundScheduler
+import pytz
+import json
+from services import update_league_data
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    """
+    Rota principal da API.
+
+    Retorna uma mensagem de saudação.
+    """
+    return {"message": "Hello World"}
+
+
+@app.on_event("startup")
+def start_recurring_update():
+    """
+    Inicia uma tarefa de atualização recorrente das ligas.
+
+    Esta função é executada na inicialização do aplicativo e agenda uma tarefa
+    para atualizar os dados das ligas diariamente às 6:30 da manhã.
+    """
+    tz = pytz.timezone('America/Sao_Paulo')
+    scheduler = BackgroundScheduler(timezone=tz)
+    scheduler.add_job(bulk_update_data, 'cron', hour=6, minute=30)
+    scheduler.start()
+
+
+@app.post("/bulk-update-standings-data/")
+async def bulk_update_data():
+    """
+    Atualiza os dados das ligas com base em um arquivo JSON.
+
+    Este endpoint lê um arquivo JSON contendo informações das ligas e realiza a
+    atualização dos dados de todas as ligas especificadas no arquivo.
+
+    Retorna uma mensagem de sucesso após a atualização.
+    """
+    try:
+        with open("leagues.json", "r") as file:
+            leagues = json.load(file)
+
+        for league in leagues:
+            await update_league_data(league["league_id"], league["season"])
+
+        return {"message": "Data updated successfully for all leagues"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/manual-update-standings-data/")
+async def update_data(league_id: int, season: int):
+    """
+    Atualiza manualmente os dados de uma liga específica.
+
+    Este endpoint permite a atualização manual dos dados de uma liga específica
+    com base no ID da liga e na temporada fornecidos como parâmetros.
+
+    Retorna uma mensagem de sucesso após a atualização.
+    """
+    try:
+        await update_league_data(league_id, season)
+        return {"message": "Data updated successfully"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+e esse o db.py:
+
+from pymongo import MongoClient
+from os import getenv
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class MongoDB:
+    def __init__(self):
+        self.client = MongoClient(getenv('MONGODB_URI'))
+        self.db = self.client[getenv('DB_NAME')]
+        self.collection = self.db[getenv('COLLECTION_NAME')]
+
+    def update_league_data(self, league_id: int, season: int, data: dict):
+        query = {"league_info.id": league_id, "league_info.season": season}
+        new_data = {"$set": data}
+        self.collection.update_one(query, new_data, upsert=True)
+
+    # Adicione aqui outras funções relacionadas a operações no banco de dados, se necessário.
+    # Por exemplo, funções para consultar dados, deletar documentos, etc.
+
+# Usando a classe no seu código
+# db_instance = MongoDB()
+# db_instance.update_league_data(39, 2023, data)
+
+
+Agora que temos as tabelas atualizadas dos campeonatos em nosso banco, mos focar no objetivo de criar um endpoint para extrair os jogos do dia de cada campeonato e retornar apenas os ids dos confrontos entre times do primeiro contra times do ultimo quartil de acordo com a tabela do campeonato
+```
+
+### Prompt-2
+
+```
+Eu estou extraindo dados de uma API voltada a futebol. Voce pode ver no meu services.py abaixo como isso está sendo feito para as tabelas dos campeonatos:
+
+import json
+import http.client
+import db
+from os import getenv
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_FOOTBALL_KEY = getenv('API_FOOTBALL_KEY')
+db_instance = db.MongoDB()
+
+
+def get_football_data(league_id: int, season: int) -> str:
+    conn = http.client.HTTPSConnection("api-football-v1.p.rapidapi.com")
+
+    headers = {
+        'X-RapidAPI-Key': API_FOOTBALL_KEY,
+        'X-RapidAPI-Host': "api-football-v1.p.rapidapi.com"
+    }
+
+    print(headers)
+
+    conn.request(
+        "GET", f"/v3/standings?season={season}&league={league_id}", headers=headers)
+
+    res = conn.getresponse()
+    data = res.read()
+
+    return data.decode("utf-8")
+
+
+def organize_data(data_json: dict) -> dict:
+    organized_data = {
+        "league_info": {
+            "id": data_json["response"][0]["league"]["id"],
+            "name": data_json["response"][0]["league"]["name"],
+            "country": data_json["response"][0]["league"]["country"],
+            "logo": data_json["response"][0]["league"]["logo"],
+            "flag": data_json["response"][0]["league"]["flag"],
+            "season": data_json["response"][0]["league"]["season"],
+        },
+        "standings": []
+    }
+
+    for entry in data_json["response"][0]["league"]["standings"][0]:
+        team_data = {
+            "rank": entry["rank"],
+            "team_id": entry["team"]["id"],
+            "team_name": entry["team"]["name"],
+            "points": entry["points"],
+            "goalsDiff": entry["goalsDiff"],
+            "form": entry["form"],
+        }
+        organized_data["standings"].append(team_data)
+
+    return organized_data
+
+
+async def update_league_data(league_id: int, season: int):
+    raw_data = get_football_data(league_id, season)
+    data_json = json.loads(raw_data)
+    organized_data = organize_data(data_json)
+    db_instance.update_league_data(league_id, season, organized_data)
+
+
+
+Para os jogos do dia, essa api tem um endpoint /fixtures/ que retorna os jogos e tem diversos filtros:
+
+QUERY PARAMETERS
+id
+integer
+Value: "id"
+The id of the fixture
+
+ids
+stringsMaximum of 20 fixtures ids
+Value: "id-id-id"
+One or more fixture ids
+
+live
+string
+Enum: "all" "id-id"
+All or several leagues ids
+
+date
+stringYYYY-MM-DD
+A valid date
+
+league
+integer
+The id of the league
+
+season
+integer = 4 characters YYYY
+The season of the league
+
+team
+integer
+The id of the team
+
+last
+integer <= 2 characters
+For the X last fixtures
+
+next
+integer <= 2 characters
+For the X next fixtures
+
+from
+stringYYYY-MM-DD
+A valid date
+
+to
+stringYYYY-MM-DD
+A valid date
+
+round
+string
+The round of the fixture
+
+status
+string
+Enum: "NS" "NS-PST-FT"
+One or more fixture status short
+
+venue
+integer
+The venue id of the fixture
+
+timezone
+string
+A valid timezone from the endpoint Timezone
+```


### PR DESCRIPTION
## Descrição

Este pull request adiciona duas novas rotas à API:

1. **Rota para Capturar e Armazenar Próximos Confrontos do Dia**
   - Uma nova rota foi criada para capturar e armazenar os dados dos próximos confrontos do dia de diversos campeonatos. Isso é útil para manter atualizadas as informações sobre os jogos que ocorrerão em um determinado dia.
   - Rota: `/update_today_matches_for_all_leagues/`
   - Issue relacionada: #8

2. **Rota para Retornar Confrontos Entre Top X e Últimos Y**
   - Outra nova rota foi adicionada à API para retornar os confrontos entre as equipes que estão no top X e as equipes que estão nos últimos Y lugares na classificação.
   - Rota: `/today_quartile_matches/{league_id}/{season}`
   - Issue relacionada: #5

## Alterações Propostas

- Adição de código para as novas rotas mencionadas acima.
- Documentação atualizada para descrever as novas rotas e como usá-las.

## Issues Relacionadas

- #8
- #5
