### PR TITLE
Feature/confrontos filtrados

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -207,7 +207,6 @@ class MongoDB:
         away_team = teams.get('away', {})
         home_id = home_team.get('id', 0)
         away_id = away_team.get('id', 0)
-        print(away_id)
 
         # Obtain team statistics using the team IDs
         home_team_stats = self.get_team_stats(home_id)

--- a/app/db.py
+++ b/app/db.py
@@ -92,6 +92,26 @@ class MongoDB:
 
         self.collection.update_one(query, new_data)
 
+    def get_all_week_matches(self, season: int):
+        """
+        Obtém os jogos da semana para todas as ligas do banco de dados MongoDB em uma temporada específica.
+
+        Args:
+        - season (int): Temporada.
+
+        Returns:
+        - list: Uma lista de informações completas dos jogos da semana para todas as ligas.
+        """
+        query = {
+            "league_info.season": season,
+            "week_matches": {"$exists": True, "$not": {"$size": 0}}
+        }
+
+        projection = {"_id": 0, "week_matches": 1}
+        matches = self.collection.find(query, projection)
+
+        return list(matches)
+
     def get_week_matches(self, league_id: int, season: int):
         """
         Obtém os jogos da semana para uma liga específica do banco de dados MongoDB.

--- a/app/main.py
+++ b/app/main.py
@@ -152,19 +152,17 @@ async def get_detailed_match_data_endpoint(match_id: int):
 
 @app.get("/confrontos-filtrados")
 def obter_confrontos_filtrados(
-    cartoes_min_time: float = Query(...,
-                                    description="Mínimo de cartões por jogo de um time"),
-    cartoes_min_total: float = Query(
-        ..., description="Mínimo de cartões consolidados (time1 + time2)")
+    season: int = Query(...,
+                        description="Temporada dos confrontos"),
+    cartoes_min_por_time: float = Query(...,
+                                        description="Mínimo de média de cartões por jogo de um dos times"),
+    cartoes_media_somada: float = Query(
+        ..., description="Mínimo de média de cartões somada (avg_time1 + avg_time2)")
 ):
-    confrontos = services.get_week_matches_from_db()
 
-    confrontos_filtrados_cpt = services.filtrar_confrontos_cartoes_time(
-        confrontos, cartoes_min_time)
-    confrontos_filtrados_ctotal = services.filtrar_confrontos_cartoes_total(
-        confrontos, cartoes_min_total)
+    confrontos_filtrados = services.filtrar_todos_confrontos(
+        season, cartoes_min_por_time, cartoes_media_somada)
 
     return {
-        "h2h_filtered_by_cardsperteam": confrontos_filtrados_cpt,
-        "h2h_filtered_by_cardstotal": confrontos_filtrados_ctotal
+        "confrontos_filtrados": confrontos_filtrados
     }

--- a/app/main.py
+++ b/app/main.py
@@ -152,19 +152,17 @@ async def get_detailed_match_data_endpoint(match_id: int):
 
 @app.get("/confrontos-filtrados")
 def obter_confrontos_filtrados(
-    cartoes_min_time: float = Query(...,
-                                    description="Mínimo de cartões por jogo de um time"),
-    cartoes_min_total: float = Query(
-        ..., description="Mínimo de cartões consolidados (time1 + time2)")
+    season: int = Query(...,
+                        description="Temporada dos confrontos"),
+    cartoes_min_por_time: float = Query(...,
+                                        description="Mínimo de cartões por jogo de um time"),
+    cartoes_media_somada: float = Query(
+        ..., description="Mínimo de média de cartões consolidada (avg_time1 + avg_time2)")
 ):
-    confrontos = services.get_week_matches_from_db()
 
-    confrontos_filtrados_cpt = services.filtrar_confrontos_cartoes_time(
-        confrontos, cartoes_min_time)
-    confrontos_filtrados_ctotal = services.filtrar_confrontos_cartoes_total(
-        confrontos, cartoes_min_total)
+    confrontos_filtrados = services.filtrar_todos_confrontos(
+        season, cartoes_min_por_time, cartoes_media_somada)
 
     return {
-        "h2h_filtered_by_cardsperteam": confrontos_filtrados_cpt,
-        "h2h_filtered_by_cardstotal": confrontos_filtrados_ctotal
+        "confrontos_filtrados": confrontos_filtrados
     }

--- a/app/main.py
+++ b/app/main.py
@@ -148,3 +148,21 @@ async def get_detailed_match_data_endpoint(match_id: int):
         return detailed_data
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/confrontos-filtrados")
+def obter_confrontos_filtrados(
+    cartoes_min_time: float = Query(..., description="Mínimo de cartões por jogo de um time"),
+    cartoes_min_total: float = Query(..., description="Mínimo de cartões consolidados (time1 + time2)")
+):
+    # Obtenha a lista de confrontos do seu banco de dados
+    confrontos = obter_confrontos_do_banco()  # Substitua com sua lógica para obter os confrontos
+
+    # Aplique os filtros com base nos parâmetros fornecidos
+    confrontos_filtrados_time = filtrar_confrontos_cartoes_time(confrontos, cartoes_min_time)
+    confrontos_filtrados_total = filtrar_confrontos_cartoes_total(confrontos, cartoes_min_total)
+
+    return {
+        "confrontos_filtrados_time": confrontos_filtrados_time,
+        "confrontos_filtrados_total": confrontos_filtrados_total
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Query, HTTPException
 from apscheduler.schedulers.background import BackgroundScheduler
 import pytz
 import json
@@ -152,17 +152,19 @@ async def get_detailed_match_data_endpoint(match_id: int):
 
 @app.get("/confrontos-filtrados")
 def obter_confrontos_filtrados(
-    cartoes_min_time: float = Query(..., description="Mínimo de cartões por jogo de um time"),
-    cartoes_min_total: float = Query(..., description="Mínimo de cartões consolidados (time1 + time2)")
+    cartoes_min_time: float = Query(...,
+                                    description="Mínimo de cartões por jogo de um time"),
+    cartoes_min_total: float = Query(
+        ..., description="Mínimo de cartões consolidados (time1 + time2)")
 ):
-    # Obtenha a lista de confrontos do seu banco de dados
-    confrontos = obter_confrontos_do_banco()  # Substitua com sua lógica para obter os confrontos
+    confrontos = services.get_week_matches_from_db()
 
-    # Aplique os filtros com base nos parâmetros fornecidos
-    confrontos_filtrados_time = filtrar_confrontos_cartoes_time(confrontos, cartoes_min_time)
-    confrontos_filtrados_total = filtrar_confrontos_cartoes_total(confrontos, cartoes_min_total)
+    confrontos_filtrados_cpt = services.filtrar_confrontos_cartoes_time(
+        confrontos, cartoes_min_time)
+    confrontos_filtrados_ctotal = services.filtrar_confrontos_cartoes_total(
+        confrontos, cartoes_min_total)
 
     return {
-        "confrontos_filtrados_time": confrontos_filtrados_time,
-        "confrontos_filtrados_total": confrontos_filtrados_total
+        "h2h_filtered_by_cardsperteam": confrontos_filtrados_cpt,
+        "h2h_filtered_by_cardstotal": confrontos_filtrados_ctotal
     }

--- a/app/services.py
+++ b/app/services.py
@@ -286,7 +286,7 @@ def get_today_matches_from_db(league_id: int, season: int):
     return db_instance.get_today_matches(league_id, season)
 
 
-def get_week_matches_from_db(league_id: int, season: int):
+def get_week_matches_from_db(season: int):
     """
     Obtém os jogos do dia para uma liga específica do banco de dados MongoDB.
 
@@ -298,7 +298,7 @@ def get_week_matches_from_db(league_id: int, season: int):
     - list: Uma lista de informações completas dos jogos do dia.
     """
     # Chama o método do banco de dados para obter os jogos do dia
-    return db_instance.get_all_week_matches(league_id, season)
+    return db_instance.get_all_week_matches(season)
 
 
 @global_rate_limited
@@ -378,22 +378,38 @@ def get_detailed_match_data(match_id):
     return db_instance.get_detailed_match_data(match_id)
 
 
-def filtrar_confrontos_cartoes_time(confrontos, cartoes_min_time):
+def filtrar_todos_confrontos(season: int, cartoes_min_por_time: float, cartoes_media_somada: float):
+    """
+    Filtra todos os confrontos de todas as ligas em uma temporada com base em estatísticas de cartões.
+
+    Args:
+    - season (int): Temporada.
+    - cartoes_min_time (float): Valor mínimo para média de cartões por time.
+    - cartoes_min_total (float): Valor mínimo para média consolidada de cartões (time1 + time2).
+
+    Returns:
+    - list: Uma lista de informações completas dos jogos da semana filtrados.
+    """
+    all_week_matches = db_instance.get_all_week_matches(season)
     confrontos_filtrados = []
-    for confronto in confrontos:
-        if (confronto['home']['statistics']['yellow_card_avg'] > cartoes_min_time or
-                confronto['away']['statistics']['yellow_card_avg'] > cartoes_min_time):
-            confrontos_filtrados.append(confronto)
-    return confrontos_filtrados
 
+    for week_matches in all_week_matches:
+        for confronto in week_matches['week_matches']:
+            confronto = db_instance.get_detailed_match_data(
+                confronto['fixture']['id'])
+            home_yellow_card_avg = confronto['home']['statistics'].get(
+                'yellow_card_avg', 0.0)
+            away_yellow_card_avg = confronto['away']['statistics'].get(
+                'yellow_card_avg', 0.0)
 
-def filtrar_confrontos_cartoes_total(confrontos, cartoes_min_total):
-    confrontos_filtrados = []
-    for confronto in confrontos:
-        home_yellow_card_avg = confronto['home']['statistics']['yellow_card_avg']
-        away_yellow_card_avg = confronto['away']['statistics']['yellow_card_avg']
-        total_yellow_card_avg = home_yellow_card_avg + away_yellow_card_avg
+            if (home_yellow_card_avg > cartoes_min_por_time or
+                    away_yellow_card_avg > cartoes_min_por_time):
+                confrontos_filtrados.append(confronto)
+            else:
 
-        if total_yellow_card_avg > cartoes_min_total:
-            confrontos_filtrados.append(confronto)
+                total_yellow_card_avg = home_yellow_card_avg + away_yellow_card_avg
+
+                if total_yellow_card_avg > cartoes_media_somada:
+                    confrontos_filtrados.append(confronto)
+
     return confrontos_filtrados

--- a/app/services.py
+++ b/app/services.py
@@ -366,10 +366,11 @@ def get_detailed_match_data(match_id):
 def filtrar_confrontos_cartoes_time(confrontos, cartoes_min_time):
     confrontos_filtrados = []
     for confronto in confrontos:
-        if (confronto['home']['statistics']['yellow_card_avg'] > cartoes_min_time) or
-            (confronto['away']['statistics']['yellow_card_avg'] > cartoes_min_time):
+        if (confronto['home']['statistics']['yellow_card_avg'] > cartoes_min_time or
+                confronto['away']['statistics']['yellow_card_avg'] > cartoes_min_time):
             confrontos_filtrados.append(confronto)
     return confrontos_filtrados
+
 
 def filtrar_confrontos_cartoes_total(confrontos, cartoes_min_total):
     confrontos_filtrados = []

--- a/app/services.py
+++ b/app/services.py
@@ -361,3 +361,23 @@ def update_team_statistics_in_db(league_id: int, season: int, team_id: int):
 
 def get_detailed_match_data(match_id):
     return db_instance.get_detailed_match_data(match_id)
+
+
+def filtrar_confrontos_cartoes_time(confrontos, cartoes_min_time):
+    confrontos_filtrados = []
+    for confronto in confrontos:
+        if (confronto['home']['statistics']['yellow_card_avg'] > cartoes_min_time) or
+            (confronto['away']['statistics']['yellow_card_avg'] > cartoes_min_time):
+            confrontos_filtrados.append(confronto)
+    return confrontos_filtrados
+
+def filtrar_confrontos_cartoes_total(confrontos, cartoes_min_total):
+    confrontos_filtrados = []
+    for confronto in confrontos:
+        home_yellow_card_avg = confronto['home']['statistics']['yellow_card_avg']
+        away_yellow_card_avg = confronto['away']['statistics']['yellow_card_avg']
+        total_yellow_card_avg = home_yellow_card_avg + away_yellow_card_avg
+
+        if total_yellow_card_avg > cartoes_min_total:
+            confrontos_filtrados.append(confronto)
+    return confrontos_filtrados

--- a/app/services.py
+++ b/app/services.py
@@ -286,6 +286,21 @@ def get_today_matches_from_db(league_id: int, season: int):
     return db_instance.get_today_matches(league_id, season)
 
 
+def get_week_matches_from_db(league_id: int, season: int):
+    """
+    Obtém os jogos do dia para uma liga específica do banco de dados MongoDB.
+
+    Args:
+    - league_id (int): ID da liga.
+    - season (int): Temporada.
+
+    Returns:
+    - list: Uma lista de informações completas dos jogos do dia.
+    """
+    # Chama o método do banco de dados para obter os jogos do dia
+    return db_instance.get_all_week_matches(league_id, season)
+
+
 @global_rate_limited
 def get_team_statistics(league_id: int, season: int, team_id: int):
     conn = http.client.HTTPSConnection("api-football-v1.p.rapidapi.com")


### PR DESCRIPTION
## Descrição

Este pull request adiciona uma nova rota à API:

1. **Rota para retornar confrontos da semana filtrados por estatisticas pré-definidas#7**
   - Uma nova rota foi criada para retornar, dentro de um espaco de tempo de 7 dias, confrontos que satisfaçam filtros de estatísticas pré-definidas:

Exemplos:

- Confrontos com pelo menos 1 time com média de cartões acima de 3.
- Confrontos com média de cartoes consolidada.

## Alterações Propostas

- Adição de código para a nova rota mencionada acima.
- Documentação atualizada para descreve a rota e como usá-la.

## Issues Relacionadas

- #1 (User Story)
- #7 